### PR TITLE
fix: 更新SonarApi 路径为相对路径，解决baseUrl包含二级目录时的空异常

### DIFF
--- a/src/main/java/com/yujunyang/intellij/plugin/sonar/api/SonarApi.java
+++ b/src/main/java/com/yujunyang/intellij/plugin/sonar/api/SonarApi.java
@@ -27,13 +27,13 @@ import retrofit2.http.Query;
 
 public interface SonarApi {
 
-    @GET("/api/navigation/global")
+    @GET("api/navigation/global")
     Call<NavigationGlobalResponse> navigationGlobal();
 
 
-    @GET("/api/qualityprofiles/search?defaults=true")
+    @GET("api/qualityprofiles/search?defaults=true")
     Call<QualityProfilesSearchResponse> qualityProfilesSearch();
 
-    @GET("/api/rules/search?activation=true&ps=500&f=repo,name,htmlDesc,params,severity")
+    @GET("api/rules/search?activation=true&ps=500&f=repo,name,htmlDesc,params,severity")
     Call<RulesSearchResponse> rulesSearch(@Query("qprofile") String profileKey, @Query("p") int page);
 }

--- a/src/main/java/com/yujunyang/intellij/plugin/sonar/core/Report.java
+++ b/src/main/java/com/yujunyang/intellij/plugin/sonar/core/Report.java
@@ -119,6 +119,11 @@ public class Report {
                 file = Paths.get(project.getBasePath(), projectRelativePath).toFile();
                 psiFile = IdeaUtils.getPsiFile(project, file);
 
+                // 有的项目psiFile为null，导致后续异常
+                if (psiFile == null) {
+                    continue;
+                }
+
                 if (!issues.containsKey(psiFile)) {
                     issues.put(psiFile, new ArrayList<>());
                 }


### PR DESCRIPTION
根据retrofit2定义，@GET("/api/execute")会作为绝对路径处理，如果baseUrl为 https://example.com/sonar/, 那么完整地址会变为
https://example.com/api/execute。
如果需要保持子路径作为BaseUrl，那么需要采用相对路径
@GET("api/execute")，这样retrofit2会处理为https://example.com/sonar/api/execute